### PR TITLE
Vlanspublyk Culture Updates

### DIFF
--- a/ANSWR MP Edit v0.1/history/countries/VLA - Flanspublic.txt
+++ b/ANSWR MP Edit v0.1/history/countries/VLA - Flanspublic.txt
@@ -1,5 +1,6 @@
 capital = 539
-primary_culture = flanish
+primary_culture = danish
+culture = north_german
 religion = protestant
 government = trading_republic
 plurality = 10.0


### PR DESCRIPTION
Updated Vlanspublyk to align with removal of Vlanish. Allows Vlanspublyk to form Giga-Scandinavia/Baltic with Elbedeutch accepted if the lobby is full of lobotomites.
![Screenshot 2025-04-04 100151](https://github.com/user-attachments/assets/bca09129-10c6-489a-82a8-69a28cace6c5)

